### PR TITLE
CertificateSniffingMitmManager throws exceptions

### DIFF
--- a/src/main/java/org/littleshoot/proxy/mitm/SubjectAlternativeNameHolder.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/SubjectAlternativeNameHolder.java
@@ -39,8 +39,10 @@ public class SubjectAlternativeNameHolder {
     }
 
     public void addAll(Collection<List<?>> subjectAlternativeNames) {
-        for (List<?> each : subjectAlternativeNames) {
-            sans.add(parseGeneralName(each));
+        if (subjectAlternativeNames != null) {
+            for (List<?> each : subjectAlternativeNames) {
+                sans.add(parseGeneralName(each));
+            }
         }
     }
 

--- a/src/test/java/de/ganskef/test/Proxy.java
+++ b/src/test/java/de/ganskef/test/Proxy.java
@@ -40,7 +40,7 @@ public class Proxy implements IProxy {
         proxy.stop();
     }
 
-    public static void main(final String... args) {
+    public static void main(final String... args) throws Exception{
         File log4jConfigurationFile = new File("src/test/resources/log4j.xml");
         if (log4jConfigurationFile.exists()) {
             DOMConfigurator.configureAndWatch(

--- a/src/test/java/org/littleshoot/proxy/mitm/CertificateSniffingTest.java
+++ b/src/test/java/org/littleshoot/proxy/mitm/CertificateSniffingTest.java
@@ -1,0 +1,44 @@
+package org.littleshoot.proxy.mitm;
+
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This test is intended to validate the alternate
+ * CertificateSniffingMitmManager implementation.
+ */
+public class CertificateSniffingTest extends LittleProxyMitmTest {
+
+    /**
+     * Shadows the method of the base class to use the alternate MitmManager
+     * implementation in the tests.
+     */
+    @BeforeClass
+    public static void initProxy() throws Exception {
+        proxy = new LittleProxyMitmProxy(9093, new CertificateSniffingMitmManager()).start();
+    }
+
+    @Ignore
+    @Test
+    @Override
+    public void testSimpleImage() throws Exception {
+        // Disabled, since it's a duplicated test case (no mitm).
+    }
+
+    @Ignore
+    @Test
+    @Override
+    public void testCachedResponse() throws Exception {
+        // Disabled, since it's a duplicated test case (no mitm).
+    }
+
+    @Ignore
+    @Test
+    @Override
+    public void testCachedResponseSecured() throws Exception {
+        // It's impossible to get the session to sniff while offline, so you
+        // can't use CertificateSniffingMitmManager for it.
+    }
+
+}

--- a/src/test/java/org/littleshoot/proxy/mitm/LittleProxyMitmTest.java
+++ b/src/test/java/org/littleshoot/proxy/mitm/LittleProxyMitmTest.java
@@ -24,7 +24,7 @@ public class LittleProxyMitmTest {
 
     private static final String IMAGE_PATH = "src/test/resources/www/netty-in-action.gif";
 
-    private static LittleProxyMitmProxy proxy;
+    protected static LittleProxyMitmProxy proxy;
     private static Server server;
     private static Server secureServer;
 
@@ -39,6 +39,10 @@ public class LittleProxyMitmTest {
     public static void beforeClass() throws Exception {
         server = new Server(9091).start();
         secureServer = new TrustedServer(9092).start();
+    }
+
+    @BeforeClass
+    public static void initProxy() throws Exception {
         proxy = new LittleProxyMitmProxy(9093).start();
     }
 


### PR DESCRIPTION
Based on the suggestion of @rhehl in #11 I created this PR to discuss this issue (and for practice).

Ignore null in SAN holder since it's a valid return value in upstreamCert.getSubjectAlternativeNames(), if the certificate hasn't this extension. 

Added a test and reorg test classes to init this alternate MITM manager.