### PR TITLE
Multiple code improvements - squid:S1854, squid:S1213, squid:RedundantThrowsDeclarationCheck, squid:S1118, squid:S1488

### DIFF
--- a/src/main/java/org/littleshoot/proxy/mitm/BouncyCastleSslEngineSource.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/BouncyCastleSslEngineSource.java
@@ -283,7 +283,7 @@ public class BouncyCastleSslEngineSource implements SslEngineSource {
         caPrivKey = (PrivateKey) ks.getKey(authority.alias(),
                 authority.password());
 
-        TrustManager[] trustManagers = null;
+        TrustManager[] trustManagers;
         if (trustAllServers) {
             trustManagers = InsecureTrustManagerFactory.INSTANCE
                     .getTrustManagers();
@@ -291,7 +291,7 @@ public class BouncyCastleSslEngineSource implements SslEngineSource {
             trustManagers = new TrustManager[] { new MergeTrustManager(ks) };
         }
 
-        KeyManager[] keyManagers = null;
+        KeyManager[] keyManagers;
         if (sendCerts) {
             keyManagers = CertificateHelper.getKeyManagers(ks, authority);
         } else {

--- a/src/main/java/org/littleshoot/proxy/mitm/CertificateHelper.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/CertificateHelper.java
@@ -80,20 +80,6 @@ public final class CertificateHelper {
      */
     private static final String SIGNATURE_ALGORITHM = is32BitJvm() ? "SHA256" : "SHA512" + "WithRSAEncryption";
 
-    /**
-     * Uses the non-portable system property sun.arch.data.model to help
-     * determine if we are running on a 32-bit JVM. Since the majority of modern
-     * systems are 64 bits, this method "assumes" 64 bits and only returns true
-     * if sun.arch.data.model explicitly indicates a 32-bit JVM.
-     *
-     * @return true if we can determine definitively that this is a 32-bit JVM,
-     *         otherwise false
-     */
-    private static boolean is32BitJvm() {
-        Integer bits = Integer.getInteger("sun.arch.data.model");
-        return bits != null && bits == 32;
-    }
-
     private static final int ROOT_KEYSIZE = 2048;
 
     private static final int FAKE_KEYSIZE = 1024;
@@ -133,6 +119,8 @@ public final class CertificateHelper {
      */
     private static final String SSL_CONTEXT_FALLBACK_PROTOCOL = "TLSv1";
 
+    private CertificateHelper() {}
+
     public static KeyPair generateKeyPair(int keySize)
             throws NoSuchAlgorithmException, NoSuchProviderException {
         KeyPairGenerator generator = KeyPairGenerator
@@ -143,9 +131,23 @@ public final class CertificateHelper {
         return generator.generateKeyPair();
     }
 
+    /**
+     * Uses the non-portable system property sun.arch.data.model to help
+     * determine if we are running on a 32-bit JVM. Since the majority of modern
+     * systems are 64 bits, this method "assumes" 64 bits and only returns true
+     * if sun.arch.data.model explicitly indicates a 32-bit JVM.
+     *
+     * @return true if we can determine definitively that this is a 32-bit JVM,
+     *         otherwise false
+     */
+    private static boolean is32BitJvm() {
+        Integer bits = Integer.getInteger("sun.arch.data.model");
+        return bits != null && bits == 32;
+    }
+
     public static KeyStore createRootCertificate(Authority authority,
             String keyStoreType) throws NoSuchAlgorithmException,
-            NoSuchProviderException, CertIOException, IOException,
+            NoSuchProviderException, IOException,
             OperatorCreationException, CertificateException, KeyStoreException {
 
         KeyPair keyPair = generateKeyPair(ROOT_KEYSIZE);
@@ -255,9 +257,8 @@ public final class CertificateHelper {
             CertificateException {
         ContentSigner signer = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
                 .setProvider(PROVIDER_NAME).build(signedWithPrivateKey);
-        X509Certificate cert = new JcaX509CertificateConverter().setProvider(
+        return new JcaX509CertificateConverter().setProvider(
                 PROVIDER_NAME).getCertificate(certificateBuilder.build(signer));
-        return cert;
     }
 
     public static TrustManager[] getTrustManagers(KeyStore keyStore)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S1118 - Utility classes should not have public constructors.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava