### PR TITLE
Multiple code improvements - squid:S2259, squid:S1148, squid:CommentedOutCodeLine, squid:S2159, squid:S1192, squid:S1872

### DIFF
--- a/src/main/java/org/littleshoot/proxy/mitm/CertificateSniffingMitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/CertificateSniffingMitmManager.java
@@ -71,7 +71,6 @@ public class CertificateSniffingMitmManager implements MitmManager {
             throws SSLPeerUnverifiedException {
         Certificate[] peerCerts = sslSession.getPeerCertificates();
         Certificate peerCert = peerCerts[0];
-        // log.debug("Upstream Certificate: {}", peerCert);
         if (peerCert instanceof java.security.cert.X509Certificate) {
             return (java.security.cert.X509Certificate) peerCert;
         }

--- a/src/main/java/org/littleshoot/proxy/mitm/Launcher.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/Launcher.java
@@ -5,8 +5,12 @@ import java.io.File;
 import org.apache.log4j.xml.DOMConfigurator;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Launcher {
+
+    private static final Logger log = LoggerFactory.getLogger(Launcher.class);
 
     public static void main(final String... args) {
         File log4jConfigurationFile = new File(
@@ -29,7 +33,7 @@ public class Launcher {
             bootstrap.start();
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             System.exit(1);
         }
     }

--- a/src/main/java/org/littleshoot/proxy/mitm/SubjectAlternativeNameHolder.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/SubjectAlternativeNameHolder.java
@@ -47,8 +47,8 @@ public class SubjectAlternativeNameHolder {
     }
 
     private ASN1Encodable parseGeneralName(List<?> nameEntry) {
-        if (nameEntry != null && nameEntry.size() != 2) {
-            throw new IllegalArgumentException(String.valueOf(nameEntry));
+        if (nameEntry == null || nameEntry.size() != 2) {
+            throw new IllegalArgumentException(nameEntry != null ? String.valueOf(nameEntry) : "nameEntry is null");
         }
         String tag = String.valueOf(nameEntry.get(0));
         Matcher m = TAGS_PATTERN.matcher(tag);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2259 - Null pointers should not be dereferenced.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S2159 - Silly equality checks should not be made.
squid:S1192 - String literals should not be duplicated.
squid:S1872 - Classes should not be compared by name.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2259
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S2159
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1872
Please let me know if you have any questions.
George Kankava