### PR TITLE
Match only the end of the String in port replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ like this in your `FiltersSource` implementation:
         String uri = originalRequest.getUri();
         if (originalRequest.getMethod() == HttpMethod.CONNECT) {
             if (clientCtx != null) {
-                String prefix = "https://" + uri.replaceFirst(":443", "");
+                String prefix = "https://" + uri.replaceFirst(":443$", "");
                 clientCtx.channel().attr(CONNECTED_URL).set(prefix);
             }
             return new HttpFiltersAdapter(originalRequest, clientCtx);


### PR DESCRIPTION
Otherwise e.g. example.com:4433 would be changed to example.com3