### PR TITLE
Generate 2048 bit RSA certificates

### DIFF
--- a/src/main/java/org/littleshoot/proxy/mitm/CertificateHelper.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/CertificateHelper.java
@@ -81,7 +81,7 @@ public final class CertificateHelper {
 
     private static final int ROOT_KEYSIZE = 2048;
 
-    private static final int FAKE_KEYSIZE = 1024;
+    private static final int FAKE_KEYSIZE = 2048;
 
     /** The milliseconds of a day */
     private static final long ONE_DAY = 86400000L;


### PR DESCRIPTION
More and more systems are requiring RSA certificates to be of at least 2048 bit strength.

For example, [RHEL 8 and Fedora require 2048 bit or greater strength in their default configuration](https://www.redhat.com/en/blog/consistent-security-crypto-policies-red-hat-enterprise-linux-8).

On systems which implement this security requirement, Java applications acting as a client to the this proxy fail to establish connections through it with this error:
```
java.security.cert.CertPathValidatorException: Algorithm constraints check failed on keysize limits. RSA 1024bit key used with certificate: OU=[something]  Usage was tls server
```